### PR TITLE
ynh_redis_remove_db should remove only the current database

### DIFF
--- a/scripts/ynh_redis
+++ b/scripts/ynh_redis
@@ -35,5 +35,5 @@ ynh_redis_get_free_db() {
 # | arg: database - the database to erase
 ynh_redis_remove_db() {
 	local db=$1
-	redis-cli -n "$db" flushall
+	redis-cli -n "$db" flushdb
 }


### PR DESCRIPTION
## Problem

- ynh_redis_remove_db remove all databases

## Solution

- use flushdb instead of flushall to remove only the current database

As you can see below:

```bash
$ redis-cli
127.0.0.1:6379> help FLUSHALL
  FLUSHALL [ASYNC]
  summary: Remove all keys from all databases
  since: 1.0.0
  group: server
127.0.0.1:6379> help FLUSHDB
  FLUSHDB [ASYNC]
  summary: Remove all keys from the current database
  since: 1.0.0
  group: server
```

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
