### PR TITLE
Config panel: Add option to allow importing digitally signed PDFs

### DIFF
--- a/config_panel.toml
+++ b/config_panel.toml
@@ -20,10 +20,9 @@ Examples:\n- eng\n- eng+fra\n- eng+fra+chi_sim"""
 
   		[main.ocr.ocr_invalidate_digital_signatures]
 		ask = "Do you want signed PDF files to be consumed?"
-		type = "select"
-		choices.no = "{}"
-  		choices.yes = "{\"invalidate_digital_signatures\": true}"
+		type = "string"
+		default = "{}"
 		help = """\
-Read this information: https://github.com/paperless-ngx/paperless-ngx/discussions/4047\n\
+Write {"invalidate_digital_signatures": true} to the field if you want signed PDF files to be consumed. Read this information: https://github.com/paperless-ngx/paperless-ngx/discussions/4047\n\
 """
 		bind = "PAPERLESS_OCR_USER_ARGS:__INSTALL_DIR__/paperless.conf"

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -20,8 +20,9 @@ Examples:\n- eng\n- eng+fra\n- eng+fra+chi_sim"""
 
   		[main.ocr.ocr_invalidate_digital_signatures]
 		ask = "Do you want signed PDF files to be consumed?"
-		type = "boolean"
-		default = "0"
+		type = "select"
+		choices.no = "{}"
+  		choices.yes = "{\"invalidate_digital_signatures\": true}"
 		help = """\
 Read this information: https://github.com/paperless-ngx/paperless-ngx/discussions/4047\n\
 """

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -13,7 +13,16 @@ name = "Paperless-ngx configuration"
 		type = "string"
 		default = "eng"
 		help = """\
-Read this informations: https://github.com/YunoHost-Apps/paperless-ngx_ynh/tree/master/doc/PRE_INSTALL.md\n\
+Read this information: https://github.com/YunoHost-Apps/paperless-ngx_ynh/tree/master/doc/PRE_INSTALL.md\n\
 If your language contains a '-' such as chi-sim, you must use chi_sim\n\
 Examples:\n- eng\n- eng+fra\n- eng+fra+chi_sim"""
 		bind = "PAPERLESS_OCR_LANGUAGE:__INSTALL_DIR__/paperless.conf"
+
+  		[main.ocr.ocr_invalidate_digital_signatures]
+		ask = "Do you want signed PDF files to be consumed?"
+		type = "boolean"
+		default = "0"
+		help = """\
+Read this information: https://github.com/paperless-ngx/paperless-ngx/discussions/4047\n\
+"""
+		bind = "PAPERLESS_OCR_USER_ARGS:__INSTALL_DIR__/paperless.conf"


### PR DESCRIPTION
## Problem

Fixes https://github.com/YunoHost-Apps/paperless-ngx_ynh/issues/109

## Solution

Added a config panel option. I'm not sure though if this is the most user-friendly way of implementing it. The challenge is that the file is `.conf` but `PAPERLESS_OCR_USER_ARGS` expects a JSON object and is initialized with `{}` per default. 

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
