### PR TITLE
Use nltk punkt tab instead of nltk punkt

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -50,7 +50,7 @@ pushd $install_dir
 	chown -R "$app:" "$install_dir/nltk_data"
 	ynh_exec_warn_less ynh_exec_as $app $install_dir/venv/bin/python3 -m nltk.downloader -d "$install_dir/nltk_data" snowball_data
 	ynh_exec_warn_less ynh_exec_as $app $install_dir/venv/bin/python3 -m nltk.downloader -d "$install_dir/nltk_data" stopwords
-	ynh_exec_warn_less ynh_exec_as $app $install_dir/venv/bin/python3 -m nltk.downloader -d "$install_dir/nltk_data" punkt
+	ynh_exec_warn_less ynh_exec_as $app $install_dir/venv/bin/python3 -m nltk.downloader -d "$install_dir/nltk_data" punkt_tab
 
 	deactivate
 )

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -79,7 +79,7 @@ pushd $install_dir
 	chown -R "$app:" "$install_dir/nltk_data"
 	ynh_exec_warn_less ynh_exec_as $app $install_dir/venv/bin/python3 -m nltk.downloader -d "$install_dir/nltk_data" snowball_data
 	ynh_exec_warn_less ynh_exec_as $app $install_dir/venv/bin/python3 -m nltk.downloader -d "$install_dir/nltk_data" stopwords
-	ynh_exec_warn_less ynh_exec_as $app $install_dir/venv/bin/python3 -m nltk.downloader -d "$install_dir/nltk_data" punkt
+	ynh_exec_warn_less ynh_exec_as $app $install_dir/venv/bin/python3 -m nltk.downloader -d "$install_dir/nltk_data" punkt_tab
 
 	deactivate
 )


### PR DESCRIPTION
## Problem

Fixes https://github.com/YunoHost-Apps/paperless-ngx_ynh/issues/123 . 

Paperless-ngx guys changed nltk punkt to nltk punkt_tab https://github.com/paperless-ngx/paperless-ngx/commit/5a1ef27224bcb5f14319527d33ed81bee4445be0

Cloudron guys did the same in their Docker file to fix the problem https://git.cloudron.io/cloudron/paperless-ngx-app/-/commit/fc677b19cc3f78ff3a7b9b2db13297851a7545ec

## Solution

- *And how do you fix that problem*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
