### PR TITLE
Grant the virtual environment access to the system packages

### DIFF
--- a/ALL_README.md
+++ b/ALL_README.md
@@ -7,5 +7,6 @@
 - [Le o README en galego](README_gl.md)
 - [Baca README dalam bahasa bahasa Indonesia](README_id.md)
 - [Lees de README in het Nederlands](README_nl.md)
+- [Przeczytaj README w języku polski](README_pl.md)
 - [Прочитать README на русский](README_ru.md)
 - [阅读中文（简体）的 README](README_zh_Hans.md)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ It shall NOT be edited by hand.
 
 # Paperless-ngx for YunoHost
 
-[![Integration level](https://dash.yunohost.org/integration/paperless-ngx.svg)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/) ![Working status](https://ci-apps.yunohost.org/ci/badges/paperless-ngx.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/paperless-ngx.maintain.svg)
+[![Integration level](https://apps.yunohost.org/badge/integration/paperless-ngx)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/)
+![Working status](https://apps.yunohost.org/badge/state/paperless-ngx)
+![Maintenance status](https://apps.yunohost.org/badge/maintained/paperless-ngx)
 
 [![Install Paperless-ngx with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=paperless-ngx)
 

--- a/README_es.md
+++ b/README_es.md
@@ -5,7 +5,9 @@ No se debe editar a mano.
 
 # Paperless-ngx para Yunohost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/paperless-ngx.svg)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/) ![Estado funcional](https://ci-apps.yunohost.org/ci/badges/paperless-ngx.status.svg) ![Estado En Mantención](https://ci-apps.yunohost.org/ci/badges/paperless-ngx.maintain.svg)
+[![Nivel de integración](https://apps.yunohost.org/badge/integration/paperless-ngx)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/)
+![Estado funcional](https://apps.yunohost.org/badge/state/paperless-ngx)
+![Estado En Mantención](https://apps.yunohost.org/badge/maintained/paperless-ngx)
 
 [![Instalar Paperless-ngx con Yunhost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=paperless-ngx)
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -5,7 +5,9 @@ EZ editatu eskuz.
 
 # Paperless-ngx YunoHost-erako
 
-[![Integrazio maila](https://dash.yunohost.org/integration/paperless-ngx.svg)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/) ![Funtzionamendu egoera](https://ci-apps.yunohost.org/ci/badges/paperless-ngx.status.svg) ![Mantentze egoera](https://ci-apps.yunohost.org/ci/badges/paperless-ngx.maintain.svg)
+[![Integrazio maila](https://apps.yunohost.org/badge/integration/paperless-ngx)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/)
+![Funtzionamendu egoera](https://apps.yunohost.org/badge/state/paperless-ngx)
+![Mantentze egoera](https://apps.yunohost.org/badge/maintained/paperless-ngx)
 
 [![Instalatu Paperless-ngx YunoHost-ekin](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=paperless-ngx)
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -5,7 +5,9 @@ Il NE doit PAS être modifié à la main.
 
 # Paperless-ngx pour YunoHost
 
-[![Niveau d’intégration](https://dash.yunohost.org/integration/paperless-ngx.svg)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/paperless-ngx.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/paperless-ngx.maintain.svg)
+[![Niveau d’intégration](https://apps.yunohost.org/badge/integration/paperless-ngx)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/)
+![Statut du fonctionnement](https://apps.yunohost.org/badge/state/paperless-ngx)
+![Statut de maintenance](https://apps.yunohost.org/badge/maintained/paperless-ngx)
 
 [![Installer Paperless-ngx avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=paperless-ngx)
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -5,7 +5,9 @@ NON debe editarse manualmente.
 
 # Paperless-ngx para YunoHost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/paperless-ngx.svg)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/) ![Estado de funcionamento](https://ci-apps.yunohost.org/ci/badges/paperless-ngx.status.svg) ![Estado de mantemento](https://ci-apps.yunohost.org/ci/badges/paperless-ngx.maintain.svg)
+[![Nivel de integración](https://apps.yunohost.org/badge/integration/paperless-ngx)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/)
+![Estado de funcionamento](https://apps.yunohost.org/badge/state/paperless-ngx)
+![Estado de mantemento](https://apps.yunohost.org/badge/maintained/paperless-ngx)
 
 [![Instalar Paperless-ngx con YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=paperless-ngx)
 

--- a/README_id.md
+++ b/README_id.md
@@ -5,7 +5,9 @@ Ini TIDAK boleh diedit dengan tangan.
 
 # Paperless-ngx untuk YunoHost
 
-[![Tingkat integrasi](https://dash.yunohost.org/integration/paperless-ngx.svg)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/) ![Status kerja](https://ci-apps.yunohost.org/ci/badges/paperless-ngx.status.svg) ![Status pemeliharaan](https://ci-apps.yunohost.org/ci/badges/paperless-ngx.maintain.svg)
+[![Tingkat integrasi](https://apps.yunohost.org/badge/integration/paperless-ngx)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/)
+![Status kerja](https://apps.yunohost.org/badge/state/paperless-ngx)
+![Status pemeliharaan](https://apps.yunohost.org/badge/maintained/paperless-ngx)
 
 [![Pasang Paperless-ngx dengan YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=paperless-ngx)
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -5,7 +5,9 @@ Hij mag NIET handmatig aangepast worden.
 
 # Paperless-ngx voor Yunohost
 
-[![Integratieniveau](https://dash.yunohost.org/integration/paperless-ngx.svg)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/) ![Mate van functioneren](https://ci-apps.yunohost.org/ci/badges/paperless-ngx.status.svg) ![Onderhoudsstatus](https://ci-apps.yunohost.org/ci/badges/paperless-ngx.maintain.svg)
+[![Integratieniveau](https://apps.yunohost.org/badge/integration/paperless-ngx)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/)
+![Mate van functioneren](https://apps.yunohost.org/badge/state/paperless-ngx)
+![Onderhoudsstatus](https://apps.yunohost.org/badge/maintained/paperless-ngx)
 
 [![Paperless-ngx met Yunohost installeren](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=paperless-ngx)
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -1,0 +1,67 @@
+<!--
+To README zostało automatycznie wygenerowane przez <https://github.com/YunoHost/apps/tree/master/tools/readme_generator>
+Nie powinno być ono edytowane ręcznie.
+-->
+
+# Paperless-ngx dla YunoHost
+
+[![Poziom integracji](https://apps.yunohost.org/badge/integration/paperless-ngx)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/)
+![Status działania](https://apps.yunohost.org/badge/state/paperless-ngx)
+![Status utrzymania](https://apps.yunohost.org/badge/maintained/paperless-ngx)
+
+[![Zainstaluj Paperless-ngx z YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=paperless-ngx)
+
+*[Przeczytaj plik README w innym języku.](./ALL_README.md)*
+
+> *Ta aplikacja pozwala na szybką i prostą instalację Paperless-ngx na serwerze YunoHost.*  
+> *Jeżeli nie masz YunoHost zapoznaj się z [poradnikiem](https://yunohost.org/install) instalacji.*
+
+## Przegląd
+
+Paperless-ngx is a document management system that transforms your physical documents into a searchable online archive so you can keep, well, *less paper*.
+
+### Features
+
+* Organize and index your scanned documents with tags, correspondents, types, and more.
+* Performs OCR on your documents, adds selectable text to image only documents and adds tags, correspondents and document types to your documents.
+* Supports PDF documents, images, plain text files, and Office documents (Word, Excel, Powerpoint, and LibreOffice equivalents).
+* Paperless stores your documents plain on disk. Filenames and folders are managed by paperless and their format can be configured freely.
+* Single page application front end.
+* Full text search helps you find what you need.
+* Email processing: Paperless adds documents from your email accounts.
+* Machine learning powered document matching.
+* Optimized for multi core systems: Paperless-ngx consumes multiple documents in parallel.
+* The integrated sanity checker makes sure that your document archive is in good health.
+* [More screenshots are available in the documentation](https://paperless-ngx.readthedocs.io/en/latest/screenshots.html).
+
+
+**Dostarczona wersja:** 2.13.5~ynh1
+
+**Demo:** <https://demo.paperless-ngx.com/>
+
+## Zrzuty ekranu
+
+![Zrzut ekranu z Paperless-ngx](./doc/screenshots/documents-wchrome-dark.png)
+
+## Dokumentacja i zasoby
+
+- Oficjalna strona aplikacji: <https://paperless-ngx.com>
+- Oficjalna dokumentacja: <https://paperless-ngx.readthedocs.io/en/latest/usage_overview.html>
+- Oficjalna dokumentacja dla administratora: <https://paperless-ngx.readthedocs.io/en/latest/index.html>
+- Repozytorium z kodem źródłowym: <https://github.com/paperless-ngx/paperless-ngx>
+- Sklep YunoHost: <https://apps.yunohost.org/app/paperless-ngx>
+- Zgłaszanie błędów: <https://github.com/YunoHost-Apps/paperless-ngx_ynh/issues>
+
+## Informacje od twórców
+
+Wyślij swój pull request do [gałęzi `testing`](https://github.com/YunoHost-Apps/paperless-ngx_ynh/tree/testing).
+
+Aby wypróbować gałąź `testing` postępuj zgodnie z instrukcjami:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/paperless-ngx_ynh/tree/testing --debug
+lub
+sudo yunohost app upgrade paperless-ngx -u https://github.com/YunoHost-Apps/paperless-ngx_ynh/tree/testing --debug
+```
+
+**Więcej informacji o tworzeniu paczek aplikacji:** <https://yunohost.org/packaging_apps>

--- a/README_ru.md
+++ b/README_ru.md
@@ -5,7 +5,9 @@
 
 # Paperless-ngx для YunoHost
 
-[![Уровень интеграции](https://dash.yunohost.org/integration/paperless-ngx.svg)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/) ![Состояние работы](https://ci-apps.yunohost.org/ci/badges/paperless-ngx.status.svg) ![Состояние сопровождения](https://ci-apps.yunohost.org/ci/badges/paperless-ngx.maintain.svg)
+[![Уровень интеграции](https://apps.yunohost.org/badge/integration/paperless-ngx)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/)
+![Состояние работы](https://apps.yunohost.org/badge/state/paperless-ngx)
+![Состояние сопровождения](https://apps.yunohost.org/badge/maintained/paperless-ngx)
 
 [![Установите Paperless-ngx с YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=paperless-ngx)
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -5,7 +5,9 @@
 
 # YunoHost 上的 Paperless-ngx
 
-[![集成程度](https://dash.yunohost.org/integration/paperless-ngx.svg)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/) ![工作状态](https://ci-apps.yunohost.org/ci/badges/paperless-ngx.status.svg) ![维护状态](https://ci-apps.yunohost.org/ci/badges/paperless-ngx.maintain.svg)
+[![集成程度](https://apps.yunohost.org/badge/integration/paperless-ngx)](https://ci-apps.yunohost.org/ci/apps/paperless-ngx/)
+![工作状态](https://apps.yunohost.org/badge/state/paperless-ngx)
+![维护状态](https://apps.yunohost.org/badge/maintained/paperless-ngx)
 
 [![使用 YunoHost 安装 Paperless-ngx](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=paperless-ngx)
 

--- a/scripts/install
+++ b/scripts/install
@@ -38,7 +38,7 @@ ynh_add_nginx_config
 ynh_script_progression --message="Installing Python dependencies..."
 
 pushd $install_dir
-	python3 -m venv venv
+	python3 -m venv venv --system-site-packages
 	chown -R "$app:" "$install_dir"
 (
 	source "$install_dir/venv/bin/activate"

--- a/scripts/restore
+++ b/scripts/restore
@@ -61,7 +61,7 @@ ynh_script_progression --message="Installing Python dependencies..."
 
 pushd $install_dir
 	ynh_secure_remove --file="$install_dir/venv"
-	python3 -m venv venv
+	python3 -m venv venv --system-site-packages
 	chown -R "$app:" "$install_dir"
 (
 	source "$install_dir/venv/bin/activate"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -66,7 +66,7 @@ ynh_add_nginx_config
 ynh_script_progression --message="Installing Python dependencies..." --weight=5
 
 pushd $install_dir
-	python3 -m venv venv
+	python3 -m venv venv --system-site-packages
 	chown -R "$app:" "$install_dir"
 (
 	source "$install_dir/venv/bin/activate"


### PR DESCRIPTION
Attempt to fix these errors:

```
1051399 INFO    [##########++........] > Creating the admin user... [.1 minutes]
1051467 WARNING Traceback (most recent call last):
1051467 WARNING   File "/usr/bin/yunohost", line 25, in <module>
1051467 WARNING     import yunohost
1051468 WARNING ModuleNotFoundError: No module named 'yunohost'
```

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
