### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,7 +4,7 @@
 # COMMON VARIABLES
 #=================================================
 
-timezone=$(cat /etc/timezone)
+timezone=$(timedatectl show --value --property=Timezone)
 main_domain=$(cat /etc/yunohost/current_host)
 
 #=================================================


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.