### PR TITLE
Add missing libs for ghostscript

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -97,7 +97,7 @@ ram.runtime = "350M"
     main.default = 8095
 
     [resources.apt]
-    packages = "python3, python3-pip, python3-dev, python3-venv, default-libmysqlclient-dev, fonts-liberation, imagemagick, gnupg, libpq-dev, libmagic-dev, libzbar0, poppler-utils, postgresql, postgresql-contrib, unpaper, ghostscript, icc-profiles-free, qpdf, libxml2, pngquant, zlib1g, tesseract-ocr,  libxslt1-dev, redis-server, pkg-config"
+    packages = "python3, python3-pip, python3-dev, python3-venv, default-libmysqlclient-dev, fonts-liberation, imagemagick, gnupg, libpq-dev, libmagic-dev, libzbar0, poppler-utils, postgresql, postgresql-contrib, unpaper, ghostscript, icc-profiles-free, qpdf, libxml2, pngquant, zlib1g, tesseract-ocr, libxslt1-dev, redis-server, pkg-config, libx11-dev, libxt-dev, libxext-dev"
     packages_from_raw_bash = """
     if [[ $YNH_DEBIAN_VERSION == "bookworm" ]]; then
         echo "mime-support, liblept5, libatlas-base-dev";


### PR DESCRIPTION
## Problem

Had this problem when upgrading:
```
2025-10-11 18:13:07,253: DEBUG - configure: error: X11 libraries (libX11, libXt, libXext) not available, either install them, or rerun configure with "--without-x"
```

Installing the libs on my server manually solved the problem:
```
sudo apt install libx11-dev
sudo apt install libxt-dev
sudo apt install libext-dev
```

Partiallty fixes https://github.com/YunoHost-Apps/paperless-ngx_ynh/issues/195

## Solution

Added libs for ghostscript to `manifest.toml`.

Checked that they are both available for bookworm and trixie.
https://packages.debian.org/bookworm/libx11-dev
https://packages.debian.org/bookworm/libxt-dev
https://packages.debian.org/bookworm/libxext-dev

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
