### PR TITLE
fix: upstream has ubloaded a binary with the same version number

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -57,7 +57,7 @@ ram.runtime = "350M"
 
     [resources.sources.main]
     url = "https://github.com/paperless-ngx/paperless-ngx/releases/download/v2.20.5/paperless-ngx-v2.20.5.tar.xz"
-    sha256 = "29e645a244967d8b80f7b311a2d0b146c25b2bf856ac68d051f21659e56ad1aa"
+    sha256 = "730848759f510869448a159b8b9e9718460d51437eacc9db726d14affa11edcf"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset = "paperless-ngx-.*.tar.xz"


### PR DESCRIPTION
## Problem

New installations were impossible due to https://github.com/YunoHost-Apps/paperless-ngx_ynh/issues/229
## Solution

changed the sha

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
