### PR TITLE
fix(apt): libopenblas-dev as a replacement for libatlas-base-dev

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -102,8 +102,7 @@ ram.runtime = "350M"
     if [[ $YNH_DEBIAN_VERSION == "bookworm" ]]; then
         echo "mime-support, liblept5, libatlas-base-dev";
     elif [[ $YNH_DEBIAN_VERSION == "trixie" ]]; then
-        echo "media-types, mailcap, libleptonica6"
-        # FIXME : libatlas-base-dev doesn't exist in trixie anymore yet is needed for RPi ? It doesn't look like there's any obvious replacement...
+        echo "media-types, mailcap, libleptonica6, libopenblas-dev"
     fi
     """
 

--- a/tests.toml
+++ b/tests.toml
@@ -20,6 +20,3 @@ test_format = 1.0
     # -------------------------------
     # Commits to test upgrade from
     # -------------------------------
-
-    #test_upgrade_from.8236072.name = "Upgrade from 1.14.5~ynh1 (v1)"
-    test_upgrade_from.ada997b121bbcdf2b70467f4e5484cd19d4ca65f.name = "Upgrade from 2.14.7~ynh1"


### PR DESCRIPTION
## Problem

`libatlas-base-dev` is not available on Debian 13 anymore.

## Solution

Based on a discussion over at https://github.com/numpy/numpy/issues/29108#issuecomment-3371139374, it looks like the package can be replaced by `libopenblas-dev`. TO BE CONFIRMED.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
