### PR TITLE
Install missing tesseract language packages

### DIFF
--- a/config_panel.toml
+++ b/config_panel.toml
@@ -13,9 +13,9 @@ name = "Paperless-ngx configuration"
 		type = "string"
 		default = "eng"
 		help = """\
-Read this information: https://github.com/YunoHost-Apps/paperless-ngx_ynh/tree/master/doc/PRE_INSTALL.md\n\
-If your language contains a '-' such as chi-sim, you must use chi_sim\n\
-Examples:\n- eng\n- eng+fra\n- eng+fra+chi_sim"""
+Check the app's admin documentation below.\n\
+If your language contains a '-' such as `chi-sim`, you must use `chi_sim`\n\
+Examples:\n- `eng`\n- `eng+fra`\n- `eng+fra+chi_sim`"""
 		bind = "PAPERLESS_OCR_LANGUAGE:__INSTALL_DIR__/paperless.conf"
 
   		[main.ocr.ocr_invalidate_digital_signatures]
@@ -23,6 +23,6 @@ Examples:\n- eng\n- eng+fra\n- eng+fra+chi_sim"""
 		type = "string"
 		default = "{}"
 		help = """\
-Write {"invalidate_digital_signatures": true} to the field if you want signed PDF files to be consumed. Read this information: https://github.com/paperless-ngx/paperless-ngx/discussions/4047\n\
+Write `{"invalidate_digital_signatures": true}` to the field if you want signed PDF files to be consumed. Read this information: https://github.com/paperless-ngx/paperless-ngx/discussions/4047\n\
 """
 		bind = "PAPERLESS_OCR_USER_ARGS:__INSTALL_DIR__/paperless.conf"

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,10 +1,4 @@
 Paperless is performing OCR on documents and images. English is installed by default. More languages can be installed:
-  * Display a list of all Tesseract language packs `apt-cache search tesseract-ocr`
-  * Install additional language packs
-    * Example for french `sudo apt-get install tesseract-ocr-fra`
-    * Example for german `sudo apt-get install tesseract-ocr-deu`
-  * Modify config to add new languages
-    * Open the configuration
-    * You can combine multiple languages like this:
-      * One language: eng
-      * Two languages: eng+fra
+  * Check out [Tesseract OCR's documentation](https://tesseract-ocr.github.io/tessdoc/Data-Files-in-different-versions.html), to find the codes of the languages you want to add.
+    * You can also display a list of all Tesseract language packs with `apt-cache search tesseract-ocr`
+  * The app's configuration panel on this page will automatically add the corresponding `apt` dependencies

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,4 +1,4 @@
 Paperless is performing OCR on documents and images. English is installed by default. More languages can be installed:
-  * Check out [Tesseract OCR's documentation](https://tesseract-ocr.github.io/tessdoc/Data-Files-in-different-versions.html), to find the codes of the languages you want to add.
+  * Check out [Tesseract OCR's documentation](https://tesseract-ocr.github.io/tessdoc/Data-Files-in-different-versions.html) to find the codes of the languages you want to add.
     * You can also display a list of all Tesseract language packs with `apt-cache search tesseract-ocr`
   * The app's configuration panel on this page will automatically add the corresponding `apt` dependencies

--- a/scripts/config
+++ b/scripts/config
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+source /usr/share/yunohost/helpers
+
+ynh_app_config_apply() {
+    _ynh_app_config_apply
+
+    if [ "${changed[ocr_language]}" == "true" ]
+    then
+
+        IFS='+' read -ra parts <<< "$ocr_language"
+
+        for lang in "${parts[@]}"; do
+            package="tesseract-ocr-$lang"
+            if ! dpkg-query -s "$package" >/dev/null 2>&1; then
+                ynh_apt_install_dependencies $package
+            fi
+        done
+    fi
+}
+
+ynh_app_config_run $1


### PR DESCRIPTION
## Problem

Fix https://github.com/YunoHost-Apps/paperless-ngx_ynh/issues/256 .

## Solution

Install missing apt packages when new OCR language has been added via config.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
