### PR TITLE
enh(nginx): use proxy_params_no_auth

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -2,7 +2,7 @@ location __PATH__/ {
 
   proxy_pass http://localhost:__PORT__/;
 
-  include proxy_params_with_auth;
+  include proxy_params_no_auth;
 
   # These configuration options are required for WebSockets to work.
   proxy_redirect off;


### PR DESCRIPTION
Fix a final linter warning.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
