### PR TITLE
Add ExecStartPre command to systemd.service

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -13,6 +13,7 @@ WorkingDirectory=__INSTALL_DIR__/src/
 Environment=GRANIAN_HOST=::1
 Environment=GRANIAN_PORT=__PORT__
 Environment=GRANIAN_WORKERS=1
+ExecStartPre=/usr/bin/install -d -m 1770 -o __APP__ -g __APP__ /tmp/__APP__
 ExecStart=/bin/sh -c '\
   # Host: GRANIAN_HOST -> PAPERLESS_BIND_ADDR -> default \
   [ -n "$PAPERLESS_BIND_ADDR" ] && export GRANIAN_HOST=$PAPERLESS_BIND_ADDR; \


### PR DESCRIPTION
## Problem

`/tmp/__APP__` is wiped after each reboot. Fix https://github.com/YunoHost-Apps/paperless-ngx_ynh/issues/194 .

## Solution

Add `ExecStartPre=/usr/bin/install -d -m 1770 -o __APP__ -g __APP__ /tmp/__APP__` to `systemd.service`.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
